### PR TITLE
Use without printer screen

### DIFF
--- a/octoprint_autobim/static/js/autobim.js
+++ b/octoprint_autobim/static/js/autobim.js
@@ -92,6 +92,14 @@ $(function () {
             });
         }
 
+        self.addCorner = function(_) {
+            self.settings.settings.plugins.autobim.probe_points.push({x: '0', y: '0'});
+        }
+
+        removeCorner = function(_) {
+            self.settings.settings.plugins.autobim.probe_points.pop();
+        }
+
         /* OctoPrint Hooks */
 
         self.onDataUpdaterPluginMessage = function(plugin, data) {

--- a/octoprint_autobim/static/js/autobim.js
+++ b/octoprint_autobim/static/js/autobim.js
@@ -52,7 +52,7 @@ $(function () {
             });
         };
 
-        self.home = function (corner) {
+        self.home = function () {
             $.ajax({
                 url: API_BASEURL + "plugin/autobim",
                 type: "POST",

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -34,6 +34,13 @@
 
     <div class="control-group">
         <legend>Points to probe</legend>
+        <label class="control-label">First corner is reference (experimental)</label>
+        <div class="controls">
+            <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.autobim.first_corner_is_reference" />
+            <span class="help-block">
+                If the above is checked, the first point in the list is treated as reference. Else Z=0 is reference.
+            </span>
+        </div>
         <p>
             Don't forget to <button class="btn btn-primary" data-bind="click: home">Home</button> your printer before
             using the "Test" buttons below.

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -60,6 +60,12 @@
             printer probes it the point is fine. If the printer does nothing that means it cannot reach the point. You
             should try to change the coordinates until it does.
         </span></p>
+
+        <label class="control-label">Change number of corners</label>
+        <div class="controls">
+            <button class="btn btn-secondary" data-bind="click: addCorner">+</button>
+            <button class="btn btn-secondary" data-bind="click: removeCorner, enable: settings.settings.plugins.autobim.probe_points().length > 1">-</button>
+        </div>
     </div>
 
     <div class="control-group">

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_autobim"
 plugin_name = "AutoBim"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.10"
+plugin_version = "0.1.11-dev"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_autobim"
 plugin_name = "AutoBim"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.11-dev"
+plugin_version = "0.1.11"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_autobim"
 plugin_name = "AutoBim"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.11"
+plugin_version = "0.1.12-dev"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I would like to use the plugin but my printer screen does not work with M117

It is possible to use it only with octoprint and proceed to each step without the printer screen?