### PR TITLE
Add basic support for Klipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ If you are using Klipper this is setup and configured as part of
 
 Defaults are for an Ender 3 sized printer and a BLTouch. You can configure:
 
-* Firmware type (Auto/Marlin/Klipper) - you shouldn't need to change from Auto
-  * Default: `Auto`
 * Invert arrows on display, e.g. for inverse screw threads on the adjustment screws
   * Default: `Off`
 * Enable/Disable multi-pass (i.e. go on until a full round measures ok)
@@ -104,8 +102,6 @@ Defaults are for an Ender 3 sized printer and a BLTouch. You can configure:
   * Default: `False`
 * Delay between corners - Wait the given amount of seconds before moving to next corner
   * Default: `0.0`
-* G30 command (probe) custom pattern
-  * Default: Blank (use default for supported firmware)
 * Points to probe
   * Default: `(30, 30), (200, 30), (200, 200), (30, 200)` (Ender 3)
   * Note: These coordinates refer to *probe* position, while most other coordinates (e.g. what is displayed on screen)
@@ -113,11 +109,12 @@ Defaults are for an Ender 3 sized printer and a BLTouch. You can configure:
     on the first corner, display says `ok. moving to next` but nothing happens** below) or get as close as possible.
 * Show button in Navbar
   * Default: `True`
+* G30 command (probe) custom pattern
+  * Default: Blank (use default for supported firmware)
 
 Planned are (ordered by assumed priority):
 
 * Allow for a different amount of probe points
-* Pattern for `G30` response parsing
 
 ### Klipper Macro Examples
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Defaults are for an Ender 3 sized printer and a BLTouch. You can configure:
   * Default: `False`
 * Delay between corners - Wait the given amount of seconds before moving to next corner
   * Default: `0.0`
+* G30 command (probe) result pattern flavour
+  * Default: `marlin`
 * Points to probe
   * Default: `(30, 30), (200, 30), (200, 200), (30, 200)` (Ender 3)
   * Note: These coordinates refer to *probe* position, while most other coordinates (e.g. what is displayed on screen)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ I think that depends on the method, and even more on how good you are at your me
     * Send `G30 X30 Y30` over OctoPrints Terminal. Make sure to home the printer before you do.
   * [`M117` - Set LCD Message](https://marlinfw.org/docs/gcode/M117.html)
     * Send `M117 Hello World` over OctoPrints Terminal and look for `Hello World` on the printer's screen
+* Klipper firmware with:
+  * A macro to support the `G30` command
+    * This should move to the supplied `X` and `Y` positions then `PROBE`
+    * Test as per Marlin
+  * A macro to support the `G29 D` / `G29 J` commands
+    * This should execute `BED_MESH_CLEAR`
+    * Test by sending both commands over the OctoPrint terminal.
+  * Ability to display a message with the `M117` command
+    * Test as per Marlin
 
 ## Setup
 
@@ -77,6 +86,9 @@ comfortable doing it:
 
 If it probed the point your printer is correctly set up. If not, check out
 [M851 in Marlin documentation](https://marlinfw.org/docs/gcode/M851.html) for further information on the topic.
+
+If you are using Klipper this is setup and configured as part of
+[Probe Calibration](https://www.klipper3d.org/Probe_Calibrate.html) in the Klipper documentation.
 
 ## Configuration
 

--- a/octoprint_autobim/__init__.py
+++ b/octoprint_autobim/__init__.py
@@ -152,7 +152,6 @@ class AutobimPlugin(
 			has_ubl=None,
 			next_point_delay=0.0,
 			first_corner_is_reference=False,
-			firmware_type="auto",
 			g30_regex="",
 		)
 

--- a/octoprint_autobim/__init__.py
+++ b/octoprint_autobim/__init__.py
@@ -38,8 +38,8 @@ class AutobimPlugin(
 	##~~ StartupPlugin mixin
 
 	def on_after_startup(self):
-		self.g30 = G30Handler(self._printer, self._settings)
-		self.g30_tester = G30Handler(self._printer, self._settings, False)
+		self.g30 = G30Handler(self._printer, self._settings, self._logger)
+		self.g30_tester = G30Handler(self._printer, self._settings, self._logger, False)
 		self.m503 = M503Handler(self._printer)
 
 		self.handlers = [

--- a/octoprint_autobim/__init__.py
+++ b/octoprint_autobim/__init__.py
@@ -38,8 +38,8 @@ class AutobimPlugin(
 	##~~ StartupPlugin mixin
 
 	def on_after_startup(self):
-		self.g30 = G30Handler(self._printer)
-		self.g30_tester = G30Handler(self._printer, False)
+		self.g30 = G30Handler(self._printer, self._settings)
+		self.g30_tester = G30Handler(self._printer, self._settings, False)
 		self.m503 = M503Handler(self._printer)
 
 		self.handlers = [
@@ -152,6 +152,7 @@ class AutobimPlugin(
 			has_ubl=None,
 			next_point_delay=0.0,
 			first_corner_is_reference=False,
+			g30_regex="marlin"
 		)
 
 	##~~ Gcode received hook

--- a/octoprint_autobim/__init__.py
+++ b/octoprint_autobim/__init__.py
@@ -152,7 +152,8 @@ class AutobimPlugin(
 			has_ubl=None,
 			next_point_delay=0.0,
 			first_corner_is_reference=False,
-			g30_regex="marlin"
+			firmware_type="auto",
+			g30_regex="",
 		)
 
 	##~~ Gcode received hook

--- a/octoprint_autobim/g30.py
+++ b/octoprint_autobim/g30.py
@@ -21,11 +21,13 @@ class G30Handler(AsyncCommand):
 	def update_pattern(self):
 		new_custom_pattern = self._settings.get(["g30_regex"])
 		self._logger.debug(f"new_custom_pattern: {new_custom_pattern}")
-		if new_custom_pattern != self.custom_pattern and new_custom_pattern.strip() != "":
-			# using a custom pattern
-			self.pattern = re.compile(new_custom_pattern)
+		if new_custom_pattern != self.custom_pattern:
+			if new_custom_pattern.strip() != "":
+				# using a custom pattern
+				self.pattern = re.compile(new_custom_pattern)
+				self._logger.info(f"Updated custom pattern.")
+
 			self.custom_pattern = new_custom_pattern
-			self._logger.info(f"Updated custom pattern.")
 
 		if self.custom_pattern == "":
 			# not using a custom pattern

--- a/octoprint_autobim/g30.py
+++ b/octoprint_autobim/g30.py
@@ -4,14 +4,20 @@ from octoprint_autobim.async_command import AsyncCommand, Result
 
 
 class G30Handler(AsyncCommand):
-	def __init__(self, printer, ignore_ok=True):
+	def __init__(self, printer, settings, ignore_ok=True):
 		super(G30Handler, self).__init__()
 		self._printer = printer
+		self._settings = settings
 		self._ok_is_error = not ignore_ok
-		# TODO: Move pattern to settings
-		self.pattern = re.compile(r"^Bed X: -?\d+\.\d+ Y: -?\d+\.\d+ Z: (-?\d+\.\d+)$")
+		self.pattern = None
+
+	def update_pattern(self):
+		g30_regex = self._settings.get(["g30_regex"])
+		self.pattern = re.compile(r"^Bed X: -?\d+\.\d+ Y: -?\d+\.\d+ Z: (-?\d+\.\d+)$") if g30_regex == "marlin" \
+			else re.compile(r"^// Result is z=(-?\d+\.\d+)$")
 
 	def do(self, point, timeout=180):
+		self.update_pattern()
 		self._start(point)
 		return self._get(timeout)
 

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -9,6 +9,19 @@
 <form class="form-horizontal">
     <div class="control-group">
         <legend>Main settings</legend>
+        <label class="control-label">Firmware type</label>
+        <div class="controls">
+            <select data-bind="value: settings.settings.plugins.autobim.firmware_type">
+                <option value="auto">Auto</option>
+                <option value="marlin">Marlin</option>
+                <option value="klipper">Klipper</option>
+            </select>
+            <span class="help-block">
+                The type of firmware in use. Auto will use the detected value from OctoPrint.<br/>
+                This changes the output we expect from the G30 (probe) command.<br/>
+                If you are not using a supported firmware, you may specify your own pattern under "G30 command (probe) custom pattern".
+            </span>
+        </div>
         <label class="control-label">Invert arrows on display</label>
         <div class="controls">
             <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.autobim.invert" />
@@ -30,14 +43,13 @@
             <input type="number" step="0.1" class="span3 input-block-level" data-bind="value: settings.settings.plugins.autobim.next_point_delay" />
             <span class="help-block">After the current corner measured within threshold, wait the given amount of seconds before moving to next corner</span>
         </div>
-        <label class="control-label">G30 command (probe) result pattern flavour</label>
+        <label class="control-label">G30 command (probe) custom pattern</label>
         <div class="controls">
-            <select data-bind="value: settings.settings.plugins.autobim.g30_regex">
-                <option value="marlin">Marlin</option>
-                <option value="klipper">Klipper</option>
-            </select>
-            <span class="help-block">This determines how we interpret the output from the G30 probe command.<br/>
-            Ensure you save this option before testing probe points.</span>
+            <input type="text" placeholder="Use Default" data-bind="value: settings.settings.plugins.autobim.g30_regex" />
+            <span class="help-block">
+                If the Marlin or Klipper default patterns do not work for you, a custom pattern can be specified here. Blank = use default pattern.<br/>
+                This should match the line output from the G30 command which outputs the Z coordinate. The first matcher group should be the Z value (the number only).
+            </span>
         </div>
     </div>
 
@@ -52,7 +64,8 @@
         </div>
         <p>
             Don't forget to <button class="btn btn-primary" data-bind="click: home">Home</button> your printer before
-            using the "Test" buttons below.
+            using the "Test" buttons below.<br/>
+            If you have changed any settings which effect probing, such as firmware type, save the settings before testing.
         </p>
         <div class="controls" data-bind="foreach: settings.settings.plugins.autobim.probe_points">
             <div class="row" style="margin-bottom: 14px">

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -30,6 +30,14 @@
             <input type="number" step="0.1" class="span3 input-block-level" data-bind="value: settings.settings.plugins.autobim.next_point_delay" />
             <span class="help-block">After the current corner measured within threshold, wait the given amount of seconds before moving to next corner</span>
         </div>
+        <label class="control-label">G30 command (probe) result pattern flavour</label>
+        <div class="controls">
+            <select data-bind="value: settings.settings.plugins.autobim.g30_regex">
+                <option value="marlin">Marlin</option>
+                <option value="klipper">Klipper</option>
+            </select>
+            <span class="help-block">This determines how we interpret the output from the G30 probe command.</span>
+        </div>
     </div>
 
     <div class="control-group">

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -9,19 +9,6 @@
 <form class="form-horizontal">
     <div class="control-group">
         <legend>Main settings</legend>
-        <label class="control-label">Firmware type</label>
-        <div class="controls">
-            <select data-bind="value: settings.settings.plugins.autobim.firmware_type">
-                <option value="auto">Auto</option>
-                <option value="marlin">Marlin</option>
-                <option value="klipper">Klipper</option>
-            </select>
-            <span class="help-block">
-                The type of firmware in use. Auto will use the detected value from OctoPrint.<br/>
-                This changes the output we expect from the G30 (probe) command.<br/>
-                If you are not using a supported firmware, you may specify your own pattern under "G30 command (probe) custom pattern".
-            </span>
-        </div>
         <label class="control-label">Invert arrows on display</label>
         <div class="controls">
             <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.autobim.invert" />
@@ -43,14 +30,6 @@
             <input type="number" step="0.1" class="span3 input-block-level" data-bind="value: settings.settings.plugins.autobim.next_point_delay" />
             <span class="help-block">After the current corner measured within threshold, wait the given amount of seconds before moving to next corner</span>
         </div>
-        <label class="control-label">G30 command (probe) custom pattern</label>
-        <div class="controls">
-            <input type="text" placeholder="Use Default" data-bind="value: settings.settings.plugins.autobim.g30_regex" />
-            <span class="help-block">
-                If the Marlin or Klipper default patterns do not work for you, a custom pattern can be specified here. Blank = use default pattern.<br/>
-                This should match the line output from the G30 command which outputs the Z coordinate. The first matcher group should be the Z value (the number only).
-            </span>
-        </div>
     </div>
 
     <div class="control-group">
@@ -64,8 +43,7 @@
         </div>
         <p>
             Don't forget to <button class="btn btn-primary" data-bind="click: home">Home</button> your printer before
-            using the "Test" buttons below.<br/>
-            If you have changed any settings which effect probing, such as firmware type, save the settings before testing.
+            using the "Test" buttons below.
         </p>
         <div class="controls" data-bind="foreach: settings.settings.plugins.autobim.probe_points">
             <div class="row" style="margin-bottom: 14px">
@@ -97,5 +75,24 @@
             <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.autobim.button_in_navbar" />
             <span class="help-block">Needs OctoPrint restart to take effect.</span>
         </div>
+    </div>
+
+    <div class="control-group">
+        <legend>Danger Zone - only touch if you know what you are doing!</legend>
+        <div class="row">
+            <label class="control-label">Custom G30 response pattern</label>
+            <div class="controls">
+                <input type="text" placeholder="Use Default" data-bind="value: settings.settings.plugins.autobim.g30_regex" />
+            </div>
+        </div>
+        <p class="help-block">
+            If the default patterns for parsing the Probe results do not work for you, a custom pattern can be
+            specified here. Blank = use default pattern. This should be a Regex which matches the Z value of the
+            output as its first group (the number only). The default patterns are:
+        </p>
+        <ul>
+            <li>Klipper: <pre>^// Result is z=(-?\d+\.\d+)$</pre></li>
+            <li>All other (incl. Marlin)<pre>^Bed X: -?\d+\.\d+ Y: -?\d+\.\d+ Z: (-?\d+\.\d+)$</pre></li>
+        </ul>
     </div>
 </form>

--- a/octoprint_autobim/templates/autobim_settings.jinja2
+++ b/octoprint_autobim/templates/autobim_settings.jinja2
@@ -36,7 +36,8 @@
                 <option value="marlin">Marlin</option>
                 <option value="klipper">Klipper</option>
             </select>
-            <span class="help-block">This determines how we interpret the output from the G30 probe command.</span>
+            <span class="help-block">This determines how we interpret the output from the G30 probe command.<br/>
+            Ensure you save this option before testing probe points.</span>
         </div>
     </div>
 


### PR DESCRIPTION
I recently moved to Klipper away from Marlin and much prefer this plugin's style of tramming. This adds basic support for Klipper and associated documentation.

It doesn't support Klipper directly by sending different G-Codes, instead it adds the right parsing for the responses. Klipper uses can add appropriate macros for G29/G30 to avoid this plugin needing to support the alternate G-Codes.

It does:

- Make the G30 response pattern configurable with a selector for Marlin and Klipper
  - This could be made better with an "other" option allowing a custom regex, however I would need to look at how to do this in the OctoPrint settings template, it wasn't immediately obvious
  - The provided Klipper regex is based on the standard output from `PROBE` so this should work for most configurations
- Add relevant info to the README
  - Docs about the new option
  - What macros are needed and what they need to do in order to support the missing G-Codes

Let me know if you need me to do anything license-wise to accept my changes. Also happy to make any changes based on feedback.

I've tested this on my own printer - a Creality CR10s Pro V2 running Klipper and it works great.